### PR TITLE
Preview fails in subfolders

### DIFF
--- a/elfinder/volumes/base.py
+++ b/elfinder/volumes/base.py
@@ -366,8 +366,7 @@ class ElfinderVolumeDriver(object):
         path = self.decode(hash_)
         return {
             'path' : self._path(self.decode(hash_)),
-            'url' : '%s%s' % (self._options['URL'], self._relpath(path).replace(self._options['separator'], '/')),
-            'rootUrl' : self._options['URL'],
+            'url' : self._options['URL'],
             'tmbUrl' : self._options['tmbURL'],
             'disabled' : self._options['disabled'],
             'separator' : self._separator,


### PR DESCRIPTION
The reason for this is that the directory listing returned by the connector does not exact match the one elfinder expects. This causes the Foldername does appear double when calculating the full url. The preview-request then only returns a 404.

This patch resolves this issue.
