### PR TITLE
Fix setup.py clobbering already installed Pillow library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,18 @@
 from setuptools import setup, find_packages
 import elfinder
 
+# Try to detect if we have Pillow installed.
 imaging_library = list()
 try:
-    import Image
+    import Image # PIL does this, Pillow does not.
 except ImportError:
+    # Check to see if Pillow is installed...
     try:
         from PIL import Image
     except ImportError:
-        imaging_library.append('PIL')
+        # Prefer Pillow to PIL
+        imaging_library.append('Pillow>=2.0.0')
 
-print imaging_library
 setup(
       name='yawd-elfinder',
       url='http://yawd.eu/open-source-projects/yawd-elfinder/',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,16 @@
 from setuptools import setup, find_packages
 import elfinder
 
+imaging_library = list()
+try:
+    import Image
+except ImportError:
+    try:
+        from PIL import Image
+    except ImportError:
+        imaging_library.append('PIL')
+
+print imaging_library
 setup(
       name='yawd-elfinder',
       url='http://yawd.eu/open-source-projects/yawd-elfinder/',
@@ -25,7 +35,6 @@ setup(
       include_package_data = True,
       install_requires = [
         "Django>=1.5",
-        "PIL",
         "python-magic"
-        ],
+        ] + imaging_library,
 )


### PR DESCRIPTION
Do not forcibly install PIL if Pillow is already installed. Until such
time that Pillow can report itself as providing PIL, all we can do now
is just try to detect it. Hopefully Pillow will not release a version
that allows:

import Image

As this will break detection.
