### PR TITLE
"Invalid backend response. Data is not JSON" while uploading a file in IE8/9

### DIFF
--- a/elfinder/connector.py
+++ b/elfinder/connector.py
@@ -521,7 +521,7 @@ class ElfinderConnector:
             html = int(html)
         
         header = { 'Content-Type' : 'text/html; charset=utf-8' } if html else {}
-        result = { 'added' : [], 'header' : header }
+        result = { 'added' : [], 'header' : header, 'force_json_content' : True if html else False }
 
         try:
             files = FILES.getlist('upload[]')

--- a/elfinder/views.py
+++ b/elfinder/views.py
@@ -41,7 +41,7 @@ class ElfinderConnectorView(View):
             context['volume'].close(context['pointer'], context['info']['hash'])
         elif 'raw' in context and context['raw'] and 'error' in context and context['error']: #raw error, return only the error list
             kwargs['content'] = context['error']
-        elif kwargs['content_type'] == 'application/json': #return json
+        elif context.pop('force_json_content', False) or kwargs['content_type'] == 'application/json': #return json
             kwargs['content'] = json.dumps(context)
         else: #return context as is!
             kwargs['content'] = context


### PR DESCRIPTION
Uploading a file in IE8/9 results in the error message "Invalid backend response. Data is not JSON" being shown.  

yawd-elfinder correctly handles the html flag sent by elfinder to indicate the response content type must be text/html however the content returned must still be JSON.
