### PR TITLE
Use md5.hexdigest when returning available file name

### DIFF
--- a/elfinder/volumes/filesystem.py
+++ b/elfinder/volumes/filesystem.py
@@ -114,7 +114,7 @@ class ElfinderVolumeLocalFileSystem(ElfinderVolumeDriver):
                 return n
             i+=1
 
-        return name+md5(dir_)+ext
+        return name+md5(dir_).hexdigest()+ext
 
     #************************* file/dir info *********************#
 


### PR DESCRIPTION
md5() will just return a <md5 HASH object>. Use hexdigest() to get the hashed string.
